### PR TITLE
Don't require whole library in gemspec

### DIFF
--- a/activemdb.gemspec
+++ b/activemdb.gemspec
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require File.expand_path("../lib/active_mdb", __FILE__)
+require File.expand_path("../lib/active_mdb/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name = "activemdb"

--- a/lib/active_mdb.rb
+++ b/lib/active_mdb.rb
@@ -1,9 +1,6 @@
 $:.unshift(File.dirname(__FILE__))
-module ActiveMDB
-  VERSION = '0.2.3'
-end
 
-
+require 'active_mdb/version'
 require 'rubygems'
 require 'active_support/core_ext'
 require 'active_mdb/mdb_tools'

--- a/lib/active_mdb/version.rb
+++ b/lib/active_mdb/version.rb
@@ -1,0 +1,3 @@
+module ActiveMDB
+  VERSION = '0.2.4'
+end


### PR DESCRIPTION
The last of the changes required @automatthew. This only happened in some environments. It makes sense. The gemspec shouldn't ever need to require the whole app; it's defining dependencies in there itself!
So we just simply split out the version into it's own file which is a common convention.